### PR TITLE
added feature that not updating critical variables will throw an error

### DIFF
--- a/src/supernet/addSupernetValidator.ts
+++ b/src/supernet/addSupernetValidator.ts
@@ -31,6 +31,10 @@ async function main() {
     CreateSupernetTransaction.parse(
       (await provider.platform.getTx(supernetId)).tx,
     )
+
+  // Checks, if not updated will throw error
+  if (supernetId === 'ZxTjijy4iNthRzuFFzMH5RS2BgJemYxwgZbzqzEhZJWqSnwhP') throw Error('Please update the supernetId variable')
+
   const addSupernetValidatorTx: AddSupernetValidatorTransaction =
     buildAddSupernetValidatorTransaction(
       utxoSet,

--- a/src/supernet/addSupernetValidator.ts
+++ b/src/supernet/addSupernetValidator.ts
@@ -33,7 +33,8 @@ async function main() {
     )
 
   // Checks, if not updated will throw error
-  if (supernetId === 'ZxTjijy4iNthRzuFFzMH5RS2BgJemYxwgZbzqzEhZJWqSnwhP') throw Error('Please update the supernetId variable')
+  if (supernetId === 'ZxTjijy4iNthRzuFFzMH5RS2BgJemYxwgZbzqzEhZJWqSnwhP')
+    throw Error('Please update the supernetId variable')
 
   const addSupernetValidatorTx: AddSupernetValidatorTransaction =
     buildAddSupernetValidatorTransaction(

--- a/src/supernet/createChain.ts
+++ b/src/supernet/createChain.ts
@@ -31,21 +31,26 @@ async function main() {
   const vmId: DynamicId = new DynamicId('supernetevm')
   const fxIds: DynamicId[] = []
   const chainId: number = 330333
-  const genesisMintAddress: string = '0x44542FD7C3F096aE54Cc07833b1C0Dcf68B7790C'
+  const genesisMintAddress: string =
+    '0x44542FD7C3F096aE54Cc07833b1C0Dcf68B7790C'
   const genesisMintAmount: bigint = BigInt('1000000000000000000000000')
   const genesisData: string = new SupernetEVMGenesis(chainId, [
-    new EVMAllocation(
-      genesisMintAddress,
-      genesisMintAmount
-    ),
+    new EVMAllocation(genesisMintAddress, genesisMintAmount),
   ]).generate()
 
   // Checks, if not updated will throw error
-  if(supernetId === 'ZxTjijy4iNthRzuFFzMH5RS2BgJemYxwgZbzqzEhZJWqSnwhP') throw Error("Please update the supernetId variable to that of a supernet you wish to validate.")
-  if(chainName === 'Chain A') throw Error("Please update the chainName variable.")
-  if(chainId === 330333) throw Error("Please update the chainId vairable.")
-  if(genesisMintAddress === '0x44542FD7C3F096aE54Cc07833b1C0Dcf68B7790C') throw Error("Please update the genesisMintAddress variable to an address you can access.")
-  
+  if (supernetId === 'ZxTjijy4iNthRzuFFzMH5RS2BgJemYxwgZbzqzEhZJWqSnwhP')
+    throw Error(
+      'Please update the supernetId variable to that of a supernet you wish to validate.',
+    )
+  if (chainName === 'Chain A')
+    throw Error('Please update the chainName variable.')
+  if (chainId === 330333) throw Error('Please update the chainId variable.')
+  if (genesisMintAddress === '0x44542FD7C3F096aE54Cc07833b1C0Dcf68B7790C')
+    throw Error(
+      'Please update the genesisMintAddress variable to an address you can access.',
+    )
+
   const createChainTx: CreateChainTransaction = buildCreateChainTransaction(
     utxoSet,
     sendersAddresses,

--- a/src/supernet/createChain.ts
+++ b/src/supernet/createChain.ts
@@ -39,6 +39,13 @@ async function main() {
       genesisMintAmount
     ),
   ]).generate()
+
+  // Checks, if not updated will throw error
+  if(supernetId === 'ZxTjijy4iNthRzuFFzMH5RS2BgJemYxwgZbzqzEhZJWqSnwhP') throw Error("Please update the supernetId variable to that of a supernet you wish to validate.")
+  if(chainName === 'Chain A') throw Error("Please update the chainName variable.")
+  if(chainId === 330333) throw Error("Please update the chainId vairable.")
+  if(genesisMintAddress === '0x44542FD7C3F096aE54Cc07833b1C0Dcf68B7790C') throw Error("Please update the genesisMintAddress variable to an address you can access.")
+  
   const createChainTx: CreateChainTransaction = buildCreateChainTransaction(
     utxoSet,
     sendersAddresses,


### PR DESCRIPTION
I added this due to the fact that it is far too common that users forget to update critical variables, only to learn after indexation that they have:
- used the same chainId as in the example
- assigned their chain's genesis tokens to another address
and other

So I figured it would be best to catch the error before it happens, would save everybody some time