### PR TITLE
addSupernetValidator file update

### DIFF
--- a/src/supernet/addSupernetValidator.ts
+++ b/src/supernet/addSupernetValidator.ts
@@ -24,7 +24,8 @@ async function main() {
   const fee: number = (await provider.info.getTxFee()).addSupernetValidatorFee
   const nodeId: string = 'NodeID-B2GHMQ8GF6FyrvmPUX6miaGeuVLH9UwHr'
   const startTime: bigint = now() + BigInt(30)
-  const endTime: bigint = startTime + BigInt(3600 * 24 * 14 + 30)
+  const durationInDays: number = 4
+  const endTime: bigint = startTime + BigInt(3600 * 24 * durationInDays + 30)
   const weight: bigint = BigInt(100)
   const supernetId: string = 'ZxTjijy4iNthRzuFFzMH5RS2BgJemYxwgZbzqzEhZJWqSnwhP'
   const createSupernetTx: CreateSupernetTransaction =


### PR DESCRIPTION
- added variable to set durationInDays for supernet validation, and set it to 4.
- basically, users had difficulties updating this line:
```ts
const endTime: bigint = startTime + BigInt(3600 * 24 * 14 + 30)
```

And the number of days (14) is higher than the period we are telling are validators to validate the primary network for (5 days).

So I decreased the duration for supernetValidation to 4 so that users who execute the file without checking the specifics will not have errors. 

But if they need to make updates, we just point to the **durationInDays** variable.